### PR TITLE
xIisLogging and xWebsite: Add Ensure property to LogCustomFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     present in the module DscResource.Common.
   - Removed the function `Get-CurrentUser` since no code were using it.
 
+### Changed
+
+- Website
+  - Add Ensure to LogCustomFieldInformation. ([issue #571](https://github.com/dsccommunity/WebAdministrationDsc/issues/571))
+
+### Fixed
+
+- IisLogging
+  - Can now remove all LogCustomFields using Ensure. ([issue #571](https://github.com/dsccommunity/WebAdministrationDsc/issues/571))
+
 ## [4.1.0] - 2023-01-03
 
 ### Fixed
@@ -32,10 +42,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - CommonTestHelper  
   Added `Invoke-UnitTestCleanup` to get consistent cleanup of stubs.  
   Gives correct execution of integration tests when run in same PowerShell session as unit tests (no longer calling stubs).  
-  Gives correct `Restore-WebConfiguration` after integration tests when run in same PowerShell session as unit tests (no longer calling stub).  
+  Gives correct `Restore-WebConfiguration` after integration tests when run in same PowerShell session as unit tests (no longer calling stub).
 - MockWebAdministrationWindowsFeature  
   [Issue #351](https://github.com/dsccommunity/WebAdministrationDsc/issues/351)
-  Stubs now throw StubNotImplemented when they are called in order to show when a cmdlet is not mocked correctly.  
+  Stubs now throw StubNotImplemented when they are called in order to show when a cmdlet is not mocked correctly.
 
 ## [4.0.0] - 2022-09-17
 
@@ -174,9 +184,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - xWebAdministration.Common
   - Added new helper function `Get-WebConfigurationPropertyValue` to
-    help return a value of a `WebConfigurationProperty`. *This helper*
-    *function is unable to be unit tested because it is using a type*
-    *that cannot be mocked.*
+    help return a value of a `WebConfigurationProperty`. _This helper_
+    _function is unable to be unit tested because it is using a type_
+    _that cannot be mocked._
 - xWebAppPoolDefaults
   - Changed to use the new helper function `Get-WebConfigurationPropertyValue`
     so that the resource can be properly unit tested.

--- a/source/DSCResources/DSC_IisLogging/DSC_IisLogging.psm1
+++ b/source/DSCResources/DSC_IisLogging/DSC_IisLogging.psm1
@@ -500,8 +500,14 @@ function Set-LogCustomField
     <#
         Set-WebConfigurationProperty updates logfile.customFields.
     #>
-
-    Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/Sites/SiteDefaults/logFile/customFields" -Name "." -Value $setCustomFields
+    if ($setCustomFields.Count -gt 0)
+    {
+        Set-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/Sites/SiteDefaults/logFile/customFields" -Name "." -Value $setCustomFields
+    }
+    else
+    {
+        Remove-WebConfigurationProperty -PSPath 'MACHINE/WEBROOT/APPHOST' -Filter "system.applicationHost/Sites/SiteDefaults/logFile/customFields" -Name "."
+    }
 }
 
 <#

--- a/source/DSCResources/DSC_WebSite/DSC_WebSite.schema.mof
+++ b/source/DSCResources/DSC_WebSite/DSC_WebSite.schema.mof
@@ -55,4 +55,5 @@ class DSC_LogCustomFieldInformation
     [Write, Description("Field name to identify the custom field within the log file. Please note that the field name cannot contain spaces.")] String LogFieldName;
     [Write, Description("The acceptable values for this property are: RequestHeader, ResponseHeader or ServerVariable (note that enhanced logging cannot log a server variable with a name that contains lower-case characters - to include a server variable in the event log just make sure that its name consists of all upper-case characters)."),ValueMap{"RequestHeader","ResponseHeader","ServerVariable"},Values{"RequestHeader","ResponseHeader","ServerVariable"}] String SourceType;
     [Write, Description("Name of the HTTP header or server variable (depending on the Source Type you selected) that contains a value that you want to log.")] String SourceName;
+    [Write, Description("Indicates if the custom log field should be present or absent. Defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/source/Examples/Resources/IisLogging/Sample_IisLogging_LogCustomFields_EnsureAbsent.ps1
+++ b/source/Examples/Resources/IisLogging/Sample_IisLogging_LogCustomFields_EnsureAbsent.ps1
@@ -1,0 +1,31 @@
+configuration Sample_IisLogging_LogCustomFields_EnsureAbsent
+{
+    param
+    (
+        # Target nodes to apply the configuration
+        [String[]] $NodeName = 'localhost'
+    )
+
+    # Import the module that defines custom resources
+    Import-DscResource -Module WebAdministrationDsc
+
+    Node $NodeName
+    {
+        IisLogging Logging
+        {
+            LogPath = 'C:\IISLogFiles'
+            Logflags = @('Date','Time','ClientIP','ServerIP','UserAgent')
+            LogFormat = 'W3C'
+            LogTargetW3C = 'File,ETW'
+            LogCustomFields    = @(
+                DSC_LogCustomField
+                {
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                    Ensure       = 'Absent'
+                }
+            )
+        }
+    }
+}

--- a/source/Examples/Resources/IisLogging/Sample_IisLogging_LogCustomFields_EnsurePresentDefault.ps1
+++ b/source/Examples/Resources/IisLogging/Sample_IisLogging_LogCustomFields_EnsurePresentDefault.ps1
@@ -1,0 +1,30 @@
+configuration Sample_IisLogging_LogCustomFields_EnsurePresentDefault
+{
+    param
+    (
+        # Target nodes to apply the configuration
+        [String[]] $NodeName = 'localhost'
+    )
+
+    # Import the module that defines custom resources
+    Import-DscResource -Module WebAdministrationDsc
+
+    Node $NodeName
+    {
+        IisLogging Logging
+        {
+            LogPath = 'C:\IISLogFiles'
+            Logflags = @('Date','Time','ClientIP','ServerIP','UserAgent')
+            LogFormat = 'W3C'
+            LogTargetW3C = 'File,ETW'
+            LogCustomFields    = @(
+                DSC_LogCustomField
+                {
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                }
+            )
+        }
+    }
+}

--- a/source/Examples/Resources/IisLogging/Sample_IisLogging_LogCustomFields_EnsurePresentExplicitly.ps1
+++ b/source/Examples/Resources/IisLogging/Sample_IisLogging_LogCustomFields_EnsurePresentExplicitly.ps1
@@ -1,0 +1,31 @@
+configuration Sample_IisLogging_LogCustomFields_EnsurePresentExplicitly
+{
+    param
+    (
+        # Target nodes to apply the configuration
+        [String[]] $NodeName = 'localhost'
+    )
+
+    # Import the module that defines custom resources
+    Import-DscResource -Module WebAdministrationDsc
+
+    Node $NodeName
+    {
+        IisLogging Logging
+        {
+            LogPath = 'C:\IISLogFiles'
+            Logflags = @('Date','Time','ClientIP','ServerIP','UserAgent')
+            LogFormat = 'W3C'
+            LogTargetW3C = 'File,ETW'
+            LogCustomFields    = @(
+                DSC_LogCustomField
+                {
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                    Ensure       = 'Present'
+                }
+            )
+        }
+    }
+}

--- a/source/Examples/Resources/WebSite/Sample_WebSite_WithCustomLogFields_EnsureAbsent.ps1
+++ b/source/Examples/Resources/WebSite/Sample_WebSite_WithCustomLogFields_EnsureAbsent.ps1
@@ -1,4 +1,4 @@
-configuration Sample_WebSite_NewWebsite
+configuration Sample_WebSite_WithCustomLogFields_EnsureAbsent
 {
     param
     (
@@ -81,6 +81,17 @@ configuration Sample_WebSite_NewWebsite
             ServerAutoStart = $true
             PhysicalPath    = $DestinationPath
             DependsOn       = '[File]WebContent'
+            LogFlags        = @('Date','Time','ClientIP','ServerIP','UserAgent')
+            LogFormat       = 'W3C'
+            LogCustomFields = @(
+                DSC_LogCustomFieldInformation
+                {
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                    Ensure       = 'Absent'
+                }
+            )
         }
     }
 }

--- a/source/Examples/Resources/WebSite/Sample_WebSite_WithCustomLogFields_EnsurePresentDefault.ps1
+++ b/source/Examples/Resources/WebSite/Sample_WebSite_WithCustomLogFields_EnsurePresentDefault.ps1
@@ -1,4 +1,4 @@
-configuration Sample_WebSite_NewWebsite
+configuration Sample_WebSite_WithCustomLogFields_EnsurePresentDefault
 {
     param
     (
@@ -81,6 +81,16 @@ configuration Sample_WebSite_NewWebsite
             ServerAutoStart = $true
             PhysicalPath    = $DestinationPath
             DependsOn       = '[File]WebContent'
+            LogFlags        = @('Date','Time','ClientIP','ServerIP','UserAgent')
+            LogFormat       = 'W3C'
+            LogCustomFields = @(
+                DSC_LogCustomFieldInformation
+                {
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                }
+            )
         }
     }
 }

--- a/source/Examples/Resources/WebSite/Sample_WebSite_WithCustomLogFields_EnsurePresentExplicitly.ps1
+++ b/source/Examples/Resources/WebSite/Sample_WebSite_WithCustomLogFields_EnsurePresentExplicitly.ps1
@@ -1,4 +1,4 @@
-configuration Sample_WebSite_NewWebsite
+configuration Sample_WebSite_WithCustomLogFields_EnsurePresentExplicitly
 {
     param
     (
@@ -81,6 +81,17 @@ configuration Sample_WebSite_NewWebsite
             ServerAutoStart = $true
             PhysicalPath    = $DestinationPath
             DependsOn       = '[File]WebContent'
+            LogFlags        = @('Date','Time','ClientIP','ServerIP','UserAgent')
+            LogFormat       = 'W3C'
+            LogCustomFields = @(
+                DSC_LogCustomFieldInformation
+                {
+                    LogFieldName = 'ClientEncoding'
+                    SourceName   = 'Accept-Encoding'
+                    SourceType   = 'RequestHeader'
+                    Ensure       = 'Present'
+                }
+            )
         }
     }
 }

--- a/tests/Integration/DSC_IISLogging.Integration.Tests.ps1
+++ b/tests/Integration/DSC_IISLogging.Integration.Tests.ps1
@@ -132,6 +132,36 @@ try
             $currentLogSettings.customFields.Collection[1].SourceType | Should Be 'ResponseHeader'
         }
     }
+
+    Describe "$($script:dscResourceName)_LogCustomFields" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($script:dscResourceName)_LogCustomFields -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+        It 'Should remove all custom log fields' -test {
+
+            Invoke-Expression -Command "$($script:dscResourceName)_LogCustomFields -OutputPath `$TestDrive"
+            Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+
+            $currentLogSettings = Get-WebConfiguration -filter '/system.applicationHost/sites/siteDefaults/Logfile'
+
+            $currentLogSettings.directory | Should Be 'C:\IISLogFiles'
+            $currentLogSettings.logExtFileFlags | Should Be 'Date,Time,ClientIP,ServerIP,UserAgent'
+            $currentLogSettings.logformat | Should Be 'W3C'
+            $currentLogSettings.logTargetW3C | Should Be 'File,ETW'
+            $currentLogSettings.TruncateSize | Should Be '2097152'
+            $currentLogSettings.localTimeRollover | Should Be 'True'
+            $currentLogSettings.customFields.Collection | Should -BeNullOrEmpty
+        }
+    }
 }
 finally
 {

--- a/tests/Integration/DSC_IISLogging.config.ps1
+++ b/tests/Integration/DSC_IISLogging.config.ps1
@@ -84,3 +84,34 @@ configuration DSC_IisLogging_LogFlags
         )
     }
 }
+
+configuration DSC_IisLogging_LogCustomFields
+{
+    Import-DscResource -ModuleName WebAdministrationDsc
+
+    IisLogging Logging
+    {
+        LogPath = 'C:\IISLogFiles'
+        Logflags = @('Date','Time','ClientIP','ServerIP','UserAgent')
+        LoglocalTimeRollover = $true
+        LogTruncateSize = '2097152'
+        LogFormat = 'W3C'
+        LogTargetW3C = 'File,ETW'
+        LogCustomFields    = @(
+            DSC_LogCustomField
+            {
+                LogFieldName = 'ClientEncoding'
+                SourceName   = 'Accept-Encoding'
+                SourceType   = 'RequestHeader'
+                Ensure       = 'Absent'
+            }
+            DSC_LogCustomField
+            {
+                LogFieldName = 'X-Powered-By'
+                SourceName   = 'ASP.NET'
+                SourceType   = 'ResponseHeader'
+                Ensure       = 'Absent'
+            }
+        )
+    }
+}

--- a/tests/Integration/DSC_WebSite.Integration.Tests.ps1
+++ b/tests/Integration/DSC_WebSite.Integration.Tests.ps1
@@ -266,6 +266,32 @@ try
         }
     }
 
+    Describe "$($script:dscResourceName)_Custom_Logging_Configured" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($script:dscResourceName)_Custom_Logging_Configured -ConfigurationData `$dscConfig -OutputPath `$TestDrive -CertificateThumbprint `$selfSignedCert.Thumbprint"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should remove all custom log fields' -test {
+
+            Invoke-Expression -Command "$($script:dscResourceName)_Custom_Logging_Configured -ConfigurationData `$dscConfig -OutputPath `$TestDrive -CertificateThumbprint `$selfSignedCert.Thumbprint"
+
+            # Build results to test
+            $result = Get-Website -Name $dscConfig.AllNodes.Website
+
+            # Test Website has updated CustomLogFields
+            $result.logFile.LogCustomFields | Should -BeNullOrEmpty
+        }
+    }
+
     Describe "$($script:dscResourceName)_Present_Stopped" {
         #region DEFAULT TESTS
         It 'Should compile the MOF without throwing' {

--- a/tests/Integration/DSC_WebSite.config.ps1
+++ b/tests/Integration/DSC_WebSite.config.ps1
@@ -331,3 +331,41 @@ configuration DSC_WebSite_Logging_Configured
         }
     }
 }
+
+configuration DSC_WebSite_Custom_Logging_Configured
+{
+    param(
+
+        [Parameter(Mandatory = $true)]
+        [String] $CertificateThumbprint
+
+    )
+
+    Import-DscResource -ModuleName WebAdministrationDsc
+
+    Node $AllNodes.NodeName
+    {
+        WebSite Website
+        {
+            Name      = $Node.Website
+            LogFlags  = $Node.LogFlags2
+            LogFormat = $Node.LogFormat
+            LogCustomFields = @(
+                DSC_LogCustomFieldInformation
+                {
+                    LogFieldName = $Node.LogFieldName1
+                    SourceName   = $Node.SourceName1
+                    SourceType   = $Node.SourceType1
+                    Ensure       = 'Absent'
+                }
+                DSC_LogCustomFieldInformation
+                {
+                    LogFieldName = $Node.LogFieldName2
+                    SourceName   = $Node.SourceName2
+                    SourceType   = $Node.SourceType2
+                    Ensure       = 'Absent'
+                }
+            )
+        }
+    }
+}

--- a/tests/Unit/DSC_IISLogging.Tests.ps1
+++ b/tests/Unit/DSC_IISLogging.Tests.ps1
@@ -970,6 +970,7 @@ try
 
             Context 'Create new LogCustomField' {
                 Mock -CommandName Set-WebConfigurationProperty
+                Mock -CommandName Remove-WebConfigurationProperty
 
                 It 'Should not throw an error with default Ensure (Present)' {
                     { Set-LogCustomField  -LogCustomField $MockCimLogCustomFields } | Should Not Throw
@@ -984,13 +985,15 @@ try
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Remove-WebConfigurationProperty -Exactly 1
                 }
             }
 
 
             Context 'Modify existing LogCustomField' {
                 Mock -CommandName Set-WebConfigurationProperty
+                Mock -CommandName Remove-WebConfigurationProperty
 
                 It 'Should not throw an error with default Ensure (Present)' {
                     { Set-LogCustomField  -LogCustomField $MockCimLogCustomFields } | Should Not Throw
@@ -1005,7 +1008,8 @@ try
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 3
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                    Assert-MockCalled -CommandName Remove-WebConfigurationProperty -Exactly 1
                 }
             }
         }

--- a/tests/Unit/DSC_Website.Tests.ps1
+++ b/tests/Unit/DSC_Website.Tests.ps1
@@ -3977,6 +3977,29 @@ try
                     } `
                     -ClientOnly
             )
+            $MockCimLogCustomFieldsEnsurePresentExplicitly = @(
+                New-CimInstance -ClassName DSC_LogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Present'
+                    } `
+                    -ClientOnly
+            )
+
+            $MockCimLogCustomFieldsEnsureAbsent = @(
+                New-CimInstance -ClassName DSC_LogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Absent'
+                    } `
+                    -ClientOnly
+            )
 
             Context 'LogCustomField in desired state'{
                 $MockDesiredLogCustomFields = @{
@@ -3987,8 +4010,17 @@ try
 
                 Mock -CommandName Get-WebConfigurationProperty -MockWith { return $MockDesiredLogCustomFields }
 
-               It 'should return True' {
+                It 'Should return True with default Ensure (Present)' {
                     Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields | Should Be $True
+                }
+
+                It 'Should return True with explicit Ensure Present' {
+                    Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly | Should Be $True
+                }
+
+                It 'Should return True with Ensure Absent and Custom Field Absent' {
+                    Mock -CommandName Get-WebConfigurationProperty -MockWith { return $null }
+                    Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsureAbsent | Should Be $True
                 }
             }
 
@@ -4001,15 +4033,16 @@ try
 
                 Mock -CommandName Get-WebConfigurationProperty -MockWith { return $MockWrongLogCustomFields }
 
-                It 'should return False' {
+                It 'Should return False with default Ensure (Present)' {
                     Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields | Should Be $False
                 }
-            }
 
-            Context 'LogCustomField not present'{
-                Mock -CommandName Get-WebConfigurationProperty -MockWith { return $false }
+                It 'Should return False with explicit Ensure Present' {
+                    Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly | Should Be $False
+                }
 
-                It 'should return False' {
+                It 'Should return False with Ensure Present and Custom Field Absent' {
+                    Mock -CommandName Get-WebConfigurationProperty -MockWith { return $null }
                     Test-LogCustomField -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields | Should Be $False
                 }
             }
@@ -4030,27 +4063,71 @@ try
                     -ClientOnly
             )
 
+            $MockCimLogCustomFieldsEnsurePresentExplicitly = @(
+                New-CimInstance -ClassName DSC_LogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Present'
+                    } `
+                    -ClientOnly
+            )
+
+            $MockCimLogCustomFieldsEnsureAbsent = @(
+                New-CimInstance -ClassName DSC_LogCustomFieldInformation `
+                    -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                    -Property @{
+                        LogFieldName = 'ClientEncoding'
+                        SourceName   = 'Accept-Encoding'
+                        SourceType   = 'RequestHeader'
+                        Ensure       = 'Absent'
+                    } `
+                    -ClientOnly
+            )
+
             Context 'Create new LogCustomField'{
                 Mock -CommandName Set-WebConfigurationProperty
+                Mock -CommandName Remove-WebConfigurationProperty
 
-                It 'should not throw an error' {
+                It 'Should not throw an error with default Ensure (Present)' {
                     { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields } | Should Not Throw
                 }
 
-                It 'should call should call expected mocks' {
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                It 'Should not throw an error with explicit Ensure Present' {
+                    { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly } | Should Not Throw
+                }
+
+                It 'Should not throw an error with Ensure Absent' {
+                    { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsureAbsent } | Should Not Throw
+                }
+
+                It 'Should call expected mocks' {
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 4
+                    Assert-MockCalled -CommandName Remove-WebConfigurationProperty -Exactly 2
                 }
             }
 
             Context 'Modify existing LogCustomField'{
                 Mock -CommandName Set-WebConfigurationProperty
+                Mock -CommandName Remove-WebConfigurationProperty
 
-                It 'should not throw an error' {
+                It 'Should not throw an error with default Ensure (Present)' {
                     { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFields } | Should Not Throw
                 }
 
-                It 'should call should call expected mocks' {
-                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 2
+                It 'Should not throw an error with explicit Ensure Present' {
+                    { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsurePresentExplicitly } | Should Not Throw
+                }
+
+                It 'Should not throw an error with Ensure Absent' {
+                    { Set-LogCustomField  -Site $MockWebsiteName -LogCustomField $MockCimLogCustomFieldsEnsureAbsent } | Should Not Throw
+                }
+
+                It 'Should call expected mocks' {
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Exactly 4
+                    Assert-MockCalled -CommandName Remove-WebConfigurationProperty -Exactly 2
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Added the Ensure property to log custom fields in xWebsite and fixed this property in xIisLogging

#### This Pull Request (PR) fixes the following issues
Fixes #571 / #572 by allowing removal of all custom fields (previously caused error).

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/webadministrationdsc/576)
<!-- Reviewable:end -->
