### PR TITLE
WebVirtualDirectory: Using WebApplication with blank or slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Fixed
+
+- WebVirtualDirectory
+  [Issue #366](https://github.com/dsccommunity/WebAdministrationDsc/issues/366)
+  In WebVirtualDirectory WebApplication '' and '/' can now be used interchangeably.
+  - Fixed Add WebVirtualDirectory when WebApplication = '/'.
+  - Fixed Remove WebVirtualDirectory when WebApplication = ''.
+
 ## [4.0.0] - 2022-09-17
 
 ### Changed

--- a/source/DSCResources/DSC_WebVirtualDirectory/DSC_WebVirtualDirectory.psm1
+++ b/source/DSCResources/DSC_WebVirtualDirectory/DSC_WebVirtualDirectory.psm1
@@ -102,6 +102,19 @@ function Set-TargetResource
 
     if ($Ensure -eq 'Present')
     {
+        <#
+            Issue #366
+            WebApplication = '/' will cause New-WebVirtualDirectory to write
+            double slash ('//$Name') to config file.
+            This in turn causes Get-WebVirtualDirectory to not find the Virtual Directory.
+            WebApplication = '' works.
+            Note the opposite problem with Remove-WebVirtualDirectory.
+        #>
+        if ($WebApplication -eq '/')
+        {
+            $WebApplication = ''
+        }
+
         $virtualDirectory = Get-WebVirtualDirectory -Site $Website `
                                                     -Name $Name `
                                                     -Application $WebApplication
@@ -134,6 +147,18 @@ function Set-TargetResource
 
     if ($Ensure -eq 'Absent')
     {
+        <#
+            Issue #366
+            WebApplication = '' will cause Remove-WebVirtualDirectory to throw
+            "PowerShell Desired State Configuration does not support execution of commands in an interactive mode ...".
+            WebApplication = '/' works.
+            Note the opposite problem with New-WebVirtualDirectory.
+        #>
+        if ($WebApplication -eq '')
+        {
+            $WebApplication = '/'
+        }
+
         Write-Verbose -Message ($script:localizedData.VerboseSetTargetRemoveVirtualDirectory -f $Name)
         Remove-WebVirtualDirectory -Site $Website `
                                    -Application $WebApplication `

--- a/tests/Unit/DSC_WebVirtualDirectory.Tests.ps1
+++ b/tests/Unit/DSC_WebVirtualDirectory.Tests.ps1
@@ -186,6 +186,30 @@ try
                 }
             }
 
+            Context 'Ensure = Present and WebApplication = ''/''' {
+                # Issue #366
+                It 'Should change WebApplication to ''''' {
+                    $mockSite = @{
+                        Name = 'SomeName'
+                        Website = 'Website'
+                        WebApplication = '/'
+                        PhysicalPath = 'PhysicalPath'
+                    }
+
+                    Mock -CommandName New-WebVirtualDirectory -MockWith { return $null }
+
+                    Set-TargetResource -Website $mockSite.Website `
+                        -WebApplication $mockSite.WebApplication `
+                        -Name $mockSite.Name `
+                        -PhysicalPath $mockSite.PhysicalPath `
+                        -Ensure 'Present'
+
+                    Assert-MockCalled -CommandName New-WebVirtualDirectory -Exactly 1 -ParameterFilter {
+                        return "$Application" -eq ''
+                    }
+                }
+            }
+
             Context 'Ensure = Present and virtual directory exists' {
                 It 'Should call Set-ItemProperty' {
                     $mockSite = @{
@@ -228,6 +252,31 @@ try
                         -Ensure 'Absent'
 
                     Assert-MockCalled -CommandName Remove-WebVirtualDirectory -Exactly 1
+                }
+            }
+
+            Context 'Ensure = Absent and WebApplication = ''''' {
+                # Issue #366
+                It 'Should change WebApplication to ''/''' {
+                    $mockSite = @{
+                        Name = 'SomeName'
+                        Website = 'Website'
+                        WebApplication = ''
+                        PhysicalPath = 'PhysicalPath'
+                        Count = 1
+                    }
+
+                    Mock -CommandName Remove-WebVirtualDirectory -MockWith { return $null }
+
+                    Set-TargetResource -Website $mockSite.Website `
+                        -WebApplication $mockSite.WebApplication `
+                        -Name $mockSite.Name `
+                        -PhysicalPath $mockSite.PhysicalPath `
+                        -Ensure 'Absent'
+
+                    Assert-MockCalled -CommandName Remove-WebVirtualDirectory -Exactly 1 -ParameterFilter {
+                        return "$Application" -eq '/'
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description

Make `Set-TargetResource` switch between `WebApplication` '' and '/' as required by `New-WebVirtualDirectory` and `Remove-WebVirtualDirectory` respectively.

#### This Pull Request (PR) fixes the following issues

Fix #366

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/webadministrationdsc/618)
<!-- Reviewable:end -->
