### PR TITLE
WebConfigPropertyCollection - allow different property collection key types to be added, IisModule / IisMimeTypeMapping - set Ensure as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - WebConfigPropertyCollection
   - Allowed different property collection key types to be added beyond the default.
+
+### Changed
+
 - IisModule
   - Set default for Ensure property to Present.
 - IisMimeTypeMapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Added
+
+- WebConfigPropertyCollection
+  - Allowed different property collection key types to be added beyond the default.
+- IisModule
+  - Set default for Ensure property to Present.
+- IisMimeTypeMapping
+  - Set default for Ensure property to Present.
+
 ## [4.2.0] - 2024-08-26
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 * **ConfigurationPath**: This can be either an IIS configuration path in the format computername/webroot/apphost, or the IIS module path in this format IIS:\sites\Default Web Site.
 * **Extension**: The file extension to map such as **.html** or **.xml**
 * **MimeType**: The MIME type to map that extension to such as **text/html**
-* **Ensure**: Ensures that the MIME type mapping is **Present** or **Absent**.
+* **Ensure**: Ensures that the MIME type mapping is **Present** or **Absent**. Defaults to **Present**.
 
 ### IisModule
 
@@ -153,13 +153,13 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 * **Verb**: An array of allowed verbs, such as get and post.
 * **SiteName**: The name of the Site to register the module for. If empty, the resource will register the module with all of IIS.
 * **ModuleType**: The type of the module. Currently, only FastCgiModule is supported.
-* **Ensure**: Ensures that the module is **Present** or **Absent**.
+* **Ensure**: Ensures that the module is **Present** or **Absent**. Defaults to **Present**.
 
 ### SslSettings
 
 * **Name**: The Name of website in which to modify the SSL Settings
 * **Bindings**: The SSL bindings to implement.
-* **Ensure**: Ensures if the bindings are **Present** or **Absent**.
+* **Ensure**: Ensures if the bindings are **Present** or **Absent**. Defaults to **Present**.
 
 ### WebApplication
 
@@ -167,7 +167,7 @@ This resource manages the IIS configuration section locking (overrideMode) to co
 * **Name**: The desired name of the web application.
 * **WebAppPool**:  Web application’s application pool.
 * **PhysicalPath**: The path to the files that compose the web application.
-* **Ensure**: Ensures that the web application is **Present** or **Absent**.
+* **Ensure**: Ensures that the web application is **Present** or **Absent**. Defaults to **Present**.
 * **PreloadEnabled**: When set to `$true` this will allow WebSite to automatically start without a request
 * **ServiceAutoStartEnabled**: When set to `$true` this will enable Autostart on a Website
 * **ServiceAutoStartProvider**: Adds a AutostartProvider
@@ -363,7 +363,7 @@ Ensures the value of an identified property collection item's property in the we
 * **WebApplication**:  The name of the containing web application or an empty string for the containing website
 * **PhysicalPath**: The path to the files that compose the virtual directory
 * **Name**: The name of the virtual directory
-* **Ensure**: Ensures if the virtual directory is **Present** or **Absent**.
+* **Ensure**: Ensures if the virtual directory is **Present** or **Absent**. Defaults to **Present**.
 
 ## Examples
 

--- a/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.psm1
+++ b/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.psm1
@@ -120,7 +120,7 @@ function Set-TargetResource
         [String]
         $MimeType,
 
-        [Parameter]
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present'
@@ -194,7 +194,7 @@ function Test-TargetResource
         [String]
         $MimeType,
 
-        [Parameter]
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present'

--- a/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.psm1
+++ b/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.psm1
@@ -48,7 +48,7 @@ function Get-TargetResource
         [String]
         $MimeType,
 
-        [Parameter]
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [String]
         $Ensure = 'Present'

--- a/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.psm1
+++ b/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.psm1
@@ -48,10 +48,10 @@ function Get-TargetResource
         [String]
         $MimeType,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter]
         [ValidateSet('Present', 'Absent')]
         [String]
-        $Ensure
+        $Ensure = 'Present'
     )
 
     # Check if WebAdministration module is present for IIS cmdlets
@@ -120,10 +120,10 @@ function Set-TargetResource
         [String]
         $MimeType,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter]
         [ValidateSet('Present', 'Absent')]
         [String]
-        $Ensure
+        $Ensure = 'Present'
     )
 
     Assert-Module -ModuleName WebAdministration
@@ -194,10 +194,10 @@ function Test-TargetResource
         [String]
         $MimeType,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter]
         [ValidateSet('Present', 'Absent')]
         [String]
-        $Ensure
+        $Ensure = 'Present'
     )
 
     Assert-Module -ModuleName WebAdministration

--- a/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.schema.mof
+++ b/source/DSCResources/DSC_IisMimeTypeMapping/DSC_IisMimeTypeMapping.schema.mof
@@ -4,5 +4,5 @@ class DSC_IisMimeTypeMapping : OMI_BaseResource
     [Key, Description("This can be either an IIS configuration path in the format computername/webroot/apphost, or the IIS module path in this format IIS:\\sites\\Default Web Site.")] String ConfigurationPath;
     [Key, Description("The file extension to map such as .html or .xml.")] string Extension;
     [Key, Description("The MIME type to map that extension to such as text/html.")] string MimeType;
-    [Required, Description("Ensures that the MIME type mapping is Present or Absent."),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
+    [Write, Description("Ensures that the MIME type mapping is Present or Absent."),ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
 };

--- a/source/DSCResources/DSC_IisModule/DSC_IisModule.psm1
+++ b/source/DSCResources/DSC_IisModule/DSC_IisModule.psm1
@@ -104,7 +104,7 @@ function Set-TargetResource
     (
         [Parameter()]
         [ValidateSet('Present','Absent')]
-        [String] $Ensure,
+        [String] $Ensure  = 'Present',
 
         [Parameter(Mandatory = $true)]
         [String] $Path,
@@ -183,7 +183,7 @@ function Test-TargetResource
     (
         [Parameter()]
         [ValidateSet('Present','Absent')]
-        [String] $Ensure,
+        [String] $Ensure  = 'Present',
 
         [Parameter(Mandatory = $true)]
         [String] $Path,
@@ -337,7 +337,7 @@ function Test-TargetResourceImpl
 
         [Parameter()]
         [ValidateSet('Present','Absent')]
-        [String] $Ensure,
+        [String] $Ensure = 'Present',
 
         [Parameter(Mandatory = $true)]
         [HashTable] $resourceStatus

--- a/source/DSCResources/DSC_WebConfigPropertyCollection/DSC_WebConfigPropertyCollection.psm1
+++ b/source/DSCResources/DSC_WebConfigPropertyCollection/DSC_WebConfigPropertyCollection.psm1
@@ -247,6 +247,7 @@ function Set-TargetResource
                 -PSPath $WebsitePath `
                 -Filter $filter `
                 -Name '.' `
+                -Type $ItemName `
                 -Value @{
                     $ItemKeyName = $ItemKeyValue
                     $ItemPropertyName = $setItemPropertyValue

--- a/source/Examples/Resources/IisMimeTypeMapping/Sample_IisMimeTypeMapping_RemoveVideo.ps1
+++ b/source/Examples/Resources/IisMimeTypeMapping/Sample_IisMimeTypeMapping_RemoveVideo.ps1
@@ -61,7 +61,7 @@ configuration Sample_IisMimeTypeMapping_RemoveVideo
             DependsOn         = '[WindowsFeature]IIS'
         }
 
-        IisMimeTypeMapping Mpg
+        IisMimeTypeMapping Mpe
         {
             # Ensure defaults to 'Present'
             Extension         = '.mpe'

--- a/source/Examples/Resources/IisMimeTypeMapping/Sample_IisMimeTypeMapping_RemoveVideo.ps1
+++ b/source/Examples/Resources/IisMimeTypeMapping/Sample_IisMimeTypeMapping_RemoveVideo.ps1
@@ -51,11 +51,20 @@ configuration Sample_IisMimeTypeMapping_RemoveVideo
             DependsOn         = '[WindowsFeature]IIS'
         }
 
-        # we only allow the mpg Video extension on our server
+        # we only allow the mpg and mpe Video extensions on our server
         IisMimeTypeMapping Mpg
         {
             Ensure            = 'Present'
             Extension         = '.mpg'
+            MimeType          = 'video/mpeg'
+            ConfigurationPath = "IIS:\sites\$WebSiteName"
+            DependsOn         = '[WindowsFeature]IIS'
+        }
+
+        IisMimeTypeMapping Mpg
+        {
+            # Ensure defaults to 'Present'
+            Extension         = '.mpe'
             MimeType          = 'video/mpeg'
             ConfigurationPath = "IIS:\sites\$WebSiteName"
             DependsOn         = '[WindowsFeature]IIS'

--- a/tests/Integration/DSC_IISMimeTypeMapping.config.ps1
+++ b/tests/Integration/DSC_IISMimeTypeMapping.config.ps1
@@ -7,7 +7,6 @@ configuration DSC_IisMimeTypeMapping_AddMimeType
         ConfigurationPath = ''
         Extension = $ConfigurationData.NonNodeData.FileExtension
         MimeType  = $ConfigurationData.NonNodeData.MimeType
-        Ensure    = 'Present'
     }
 }
 
@@ -33,7 +32,6 @@ Configuration DSC_IisMimeTypeMapping_AddMimeTypeNestedPath
         ConfigurationPath = $ConfigurationData.NonNodeData.VirtualConfigurationPath
         Extension         = $ConfigurationData.NonNodeData.FileExtension
         MimeType          = $ConfigurationData.NonNodeData.MimeType
-        Ensure            = 'Present'
     }
 }
 

--- a/tests/Unit/DSC_WebConfigPropertyCollection.Tests.ps1
+++ b/tests/Unit/DSC_WebConfigPropertyCollection.Tests.ps1
@@ -253,6 +253,7 @@ try
 
                     Assert-MockCalled -CommandName Get-ItemValues -Times 1 -Exactly
                     Assert-MockCalled -CommandName Add-WebConfigurationProperty -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-CollectionItemPropertyType -Times 1 -Exactly
                     Assert-MockCalled -CommandName Convert-PropertyValue -Times 0 -Exactly
                 }
@@ -269,6 +270,7 @@ try
 
                     Assert-MockCalled -CommandName Get-ItemValues -Times 1 -Exactly
                     Assert-MockCalled -CommandName Add-WebConfigurationProperty -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Set-WebConfigurationProperty -Times 0 -Exactly
                     Assert-MockCalled -CommandName Get-CollectionItemPropertyType -Times 1 -Exactly
                     Assert-MockCalled -CommandName Convert-PropertyValue -Times 1 -Exactly
                 }
@@ -289,6 +291,7 @@ try
                     Set-TargetResource @script:presentParameters
 
                     Assert-MockCalled -CommandName Get-ItemValues -Times 1 -Exactly
+                    Assert-MockCalled -CommandName Add-WebConfigurationProperty -Times 0 -Exactly
                     Assert-MockCalled -CommandName Set-WebConfigurationProperty -Times 1 -Exactly
                     Assert-MockCalled -CommandName Get-CollectionItemPropertyType -Times 1 -Exactly
                     Assert-MockCalled -CommandName Convert-PropertyValue -Times 0 -Exactly

--- a/tests/Unit/DSC_WebConfigPropertyCollection.Tests.ps1
+++ b/tests/Unit/DSC_WebConfigPropertyCollection.Tests.ps1
@@ -245,6 +245,7 @@ try
             Context 'Ensure is present and collection item and property do not exist - String ItemPropertyValue' {
                 Mock -CommandName Get-ItemValues -ModuleName $script:dscResourceName
                 Mock -CommandName Add-WebConfigurationProperty
+                Mock -CommandName Set-WebConfigurationProperty
                 Mock -CommandName Get-CollectionItemPropertyType -MockWith { return 'String' }
                 Mock -CommandName Convert-PropertyValue
 
@@ -262,6 +263,7 @@ try
             Context 'Ensure is present and collection item and property do not exist - Integer ItemPropertyValue' {
                 Mock -CommandName Get-ItemValues -ModuleName $script:dscResourceName
                 Mock -CommandName Add-WebConfigurationProperty
+                Mock -CommandName Set-WebConfigurationProperty
                 Mock -CommandName Get-CollectionItemPropertyType -MockWith { return 'Int64' }
                 Mock -CommandName Convert-PropertyValue
 
@@ -283,6 +285,7 @@ try
                         allowed = 'false'
                     }
                 }
+                Mock -CommandName Add-WebConfigurationProperty
                 Mock -CommandName Set-WebConfigurationProperty -MockWith {}
                 Mock -CommandName Get-CollectionItemPropertyType -MockWith { return 'String' }
                 Mock -CommandName Convert-PropertyValue


### PR DESCRIPTION
#### Pull Request (PR) description

- Allow WebConfigPropertyCollection to be used to add different key types when there are none already (e.g. to allow https://stackoverflow.com/questions/30135330/managing-iis-net-authorization-rules-with-a-powershell-script)
- Set IisModule, IisMimeTypeMapping to have Ensure = 'Present' by default.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/WebAdministrationDsc/640)
<!-- Reviewable:end -->
